### PR TITLE
do not hardcode native modules list

### DIFF
--- a/nodeCjsDeps/Global.js
+++ b/nodeCjsDeps/Global.js
@@ -8,93 +8,20 @@
 'use strict';
 
 var Klass = require('node-klass'),
-	assert = require('assert'),
-	child_process = require('child_process'),
-	console = require('console'),
-	crypto = require('crypto'),
-	dgram = require('dgram'),
-	domain = require('domain'),
-	freelist = require('freelist'),
-	http = require('http'),
-	_linklist = require('_linklist'),
-	net = require('net'),
-	path = require('path'),
-	querystring = require('querystring'),
-	repl = require('repl'),
-	stream = require('stream'),
-	_stream_readable = require('_stream_readable'),
-	_stream_writable = require('_stream_writable'),
-	sys = require('sys'),
-	tls = require('tls'),
-	url = require('url'),
-	vm = require('vm'),
-	buffer = require('buffer'),
-	cluster = require('cluster'),
-	constants = require('constants'),
-	_debugger = require('_debugger'),
-	dns = require('dns'),
-	events = require('events'),
-	fs = require('fs'),
-	https = require('https'),
-	module = require('module'),
-	os = require('os'),
-	punycode = require('punycode'),
-	readline = require('readline'),
-	_stream_duplex = require('_stream_duplex'),
-	_stream_passthrough = require('_stream_passthrough'),
-	_stream_transform = require('_stream_transform'),
-	string_decoder = require('string_decoder'),
-	timers = require('timers'),
-	tty = require('tty'),
-	util = require('util'),
-	zlib = require('zlib'),
-	Listener = Klass.Listener;
+	Listener = Klass.Listener,
+	vm = require('vm');
+
+var nativeModules = Object.keys(process.binding('natives'))
+	.filter(function (el) { return !/^internal/.test(el); })
+	.reduce(function(accumulator, cur) {
+		accumulator[cur] = require(cur);
+		return accumulator;
+	}, {});
 
 module.exports = Klass.define('NodeCjsDeps.Global',{
 
 	statics: {
-		nodejs: {
-			assert: assert,
-			child_process: child_process,
-			console: console,
-			crypto: crypto,
-			dgram: dgram,
-			domain: domain,
-			freelist: freelist,
-			http: http,
-			_linklist: _linklist,
-			net: net,
-			path: path,
-			querystring: querystring,
-			repl: repl,
-			stream: stream,
-			_stream_readable: _stream_readable,
-			_stream_writable: _stream_writable,
-			sys: sys,
-			tls: tls,
-			url: url,
-			vm: vm,
-			buffer: buffer,
-			cluster: cluster,
-			constants: constants,
-			_debugger: _debugger,
-			dns: dns,
-			events: events,
-			fs: fs,
-			https: https,
-			module: module,
-			os: os,
-			punycode: punycode,
-			readline: readline,
-			_stream_duplex: _stream_duplex,
-			_stream_passthrough: _stream_passthrough,
-			_stream_transform: _stream_transform,
-			string_decoder: string_decoder,
-			timers: timers,
-			tty: tty,
-			util: util,
-			zlib: zlib
-		}
+		nodejs: nativeModules
 	},
 
 	constructor: function(){


### PR DESCRIPTION
The hardcoded list of native Node.js modules ties this module to a specific version of Node.js. (It's missing `v8` and others in Node 4.1.1, for example.) This PR dynamically generates the list of native Node.js modules. Unfortunately, it uses the undocumented `process.binding()` but it works on every version of Node I've tested it on (0.10.40 where it contains 40 modules, 0.12.7 where it contains 51 modules, and 4.1.1 where it contains 53 modules).
